### PR TITLE
[OT196-54] News' Form

### DIFF
--- a/src/components/news/NewsForm.js
+++ b/src/components/news/NewsForm.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { CKEditor } from "@ckeditor/ckeditor5-react";
 import ClassicEditor from "@ckeditor/ckeditor5-build-classic";
-import { errorAlert } from "../../setupAlerts";
+import { errorAlert, successAlert } from "../../setupAlerts";
 import { Form, Image } from "react-bootstrap";
 
 const NewsForm = ({ newsObject }) => {
@@ -73,12 +73,11 @@ const NewsForm = ({ newsObject }) => {
           const error = (res && res.message) || res.status;
           return Promise.reject(error);
         }
+        successAlert();
       });
     } catch (error) {
-      const iconError = "error";
-      const titleError = "There was an error!";
-      const msgError = error;
-      errorAlert(iconError, titleError, msgError);
+      errorAlert();
+      console.error(error);
     }
   };
 


### PR DESCRIPTION
https://alkemy-labs.atlassian.net/browse/OT196-54

### Summary
- New form for News

### Explanation
This form can be used on both the addition or modification of News (ony available for admin users). Both the POST and PATCH endpoints are not done yet, so I put this code on the newsRouter to check if the form works correctly:

```
router.post("/", adminValidation, async (req, res) => {
  res.send(console.log(req.body));
});

router.patch("/:id", adminValidation, async (req, res) => {
  res.send(console.log(req.params.id, req.body));
});

```
### Evidence

Sending news that are new:
![image](https://user-images.githubusercontent.com/90068543/172488294-e50cdd59-60f1-46ba-82ee-efccb9778f28.png)

Response from the server:
![image](https://user-images.githubusercontent.com/90068543/172488421-79ef5287-b1ce-4e16-b470-1f22bd5017d5.png)

If the form uses data from existent news (fake example: `<NewsForm props={} />`), the response will be:
![image](https://user-images.githubusercontent.com/90068543/172488991-d6bbb23a-6f23-4a19-a7c8-dbfca4b367d1.png)




