### PR TITLE
[OT196-64] & [OT196-101] Delete Category Backoffice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,8 @@ Thumbs.db
 # production
 /build
 
+.env
+
 # misc
 .DS_Store
 .env.local
@@ -73,4 +75,3 @@ yarn-debug.log*
 yarn-error.log*
 yarn.lock
 package-lock.json
-

--- a/src/components/categories/BtnDeleteCategory.js
+++ b/src/components/categories/BtnDeleteCategory.js
@@ -4,7 +4,13 @@ import BtnDelete from "../utils/BtnDelete";
 const BtnDeleteCategory = ({ categoryId }) => {
   const { REACT_APP_BACKEND_CATEGORIES } = process.env;
 
-  return <BtnDelete apiRoute={REACT_APP_BACKEND_CATEGORIES} id={categoryId} />;
+  return (
+    <BtnDelete
+      apiRoute={REACT_APP_BACKEND_CATEGORIES}
+      id={categoryId}
+      msgWarning="La categoría será eliminada. ¿Desea continuar?"
+    />
+  );
 };
 
 export default BtnDeleteCategory;

--- a/src/components/categories/BtnDeleteCategory.js
+++ b/src/components/categories/BtnDeleteCategory.js
@@ -1,0 +1,10 @@
+import React from "react";
+import BtnDelete from "../utils/BtnDelete";
+
+const BtnDeleteCategory = ({ categoryId }) => {
+  const { REACT_APP_BACKEND_CATEGORIES } = process.env;
+
+  return <BtnDelete apiRoute={REACT_APP_BACKEND_CATEGORIES} id={categoryId} />;
+};
+
+export default BtnDeleteCategory;

--- a/src/components/utils/BtnDelete.js
+++ b/src/components/utils/BtnDelete.js
@@ -4,7 +4,7 @@ import { FaTrashAlt } from "react-icons/fa";
 import { warningAlert, successAlert } from "../../setupAlerts";
 import axios from "axios";
 
-const BtnDelete = ({ btnLabel = "Delete", apiRoute, id }) => {
+const BtnDelete = ({ btnLabel = "Eliminar", apiRoute, id, msgWarning }) => {
   const triggerDelete = async (result, id) => {
     try {
       if (result.isConfirmed) {
@@ -20,7 +20,7 @@ const BtnDelete = ({ btnLabel = "Delete", apiRoute, id }) => {
     e.preventDefault();
     warningAlert({
       iconWarning: "warning",
-      msgWarning: "La categoría será eliminada. ¿Desea continuar?",
+      msgWarning,
       textConfirmButton: "Aceptar",
       confirmButton: true,
       textDenyButton: "Cancelar",

--- a/src/components/utils/BtnDelete.js
+++ b/src/components/utils/BtnDelete.js
@@ -1,0 +1,42 @@
+import React from "react";
+import { Button } from "react-bootstrap";
+import { FaTrashAlt } from "react-icons/fa";
+import { warningAlert, successAlert } from "../../setupAlerts";
+import axios from "axios";
+
+const BtnDelete = ({ btnLabel = "Delete", apiRoute, id }) => {
+  const triggerDelete = async (result, id) => {
+    try {
+      if (result.isConfirmed) {
+        await axios.delete(`${apiRoute}/${id}`);
+        successAlert();
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const warningDelete = (e, id) => {
+    e.preventDefault();
+    warningAlert({
+      iconWarning: "warning",
+      msgWarning: "La categoría será eliminada. ¿Desea continuar?",
+      textConfirmButton: "Aceptar",
+      confirmButton: true,
+      textDenyButton: "Cancelar",
+      denyButton: true,
+      triggerFunction: triggerDelete,
+      params: id,
+    });
+  };
+
+  return (
+    <>
+      <Button variant="danger" onClick={(e) => warningDelete(e, id)}>
+        <FaTrashAlt /> {btnLabel}
+      </Button>
+    </>
+  );
+};
+
+export default BtnDelete;


### PR DESCRIPTION
https://alkemy-labs.atlassian.net/browse/OT196-64
https://alkemy-labs.atlassian.net/browse/OT196-101

I did two tasks in this PR because they both ask for the same thing.

### Summary
- Added delete button (request a delete to the server with the given route).
- Added a Delete Category button.
- .gitignore modified to ignore .env

### Getting Started
To use this Delete Category button, you simply put: `<BtnDeleteCategory categoryId={id} />` where id is the category id of what you want to delete.

### Evidence
- Button (with default label):
![image](https://user-images.githubusercontent.com/90068543/173682803-7286c293-7606-4ba9-a0b7-cace587aa9fe.png)

- Warning alert when you click it:
![image](https://user-images.githubusercontent.com/90068543/173682881-3bc768cf-0413-4481-9b5c-bb18d0835163.png)

- Succes alert when you click "Aceptar" in the warning:
![image](https://user-images.githubusercontent.com/90068543/173683411-5a239f5b-6658-4bc9-a447-300d5d4b6199.png)

- DB changed when you success deleting a category (hardcoded id's tried: 1, 2, 3, 4, 5 and 6)
![image](https://user-images.githubusercontent.com/90068543/173683333-d648889a-832f-4774-b512-6d756e90f836.png)
